### PR TITLE
Docs: remove unused import and update text

### DIFF
--- a/src/data/MDX_CODE.tsx
+++ b/src/data/MDX_CODE.tsx
@@ -38,14 +38,14 @@ export default function HomePage() {
 
 //-------- TRY IT OUT -------------------------------//
 export const TRY_IT_OUT_CODE = `
-import { useConnected, ConnectButton, useConnectModal } from '@web3modal/react'
+import { useAccount, ConnectButton, useConnectModal } from '@web3modal/react'
 export default function YourAppContent() {
   const { isOpen, open, close } = useConnectModal()
-  const { connected } = useConnected()
+  const { account } = useAccount()
 
   return (
     <>
-      <div>{!isConnected ? <ConnectButton /> : accountButton()}</div>
+      <div>{!account.isConnected ? <ConnectButton /> : accountButton()}</div>
       {/* or */}
       <button onClick={open}>Open Modal</button>
     </>

--- a/src/data/MDX_CODE.tsx
+++ b/src/data/MDX_CODE.tsx
@@ -1,5 +1,5 @@
 //-------- GET STARTED -------------------------------//
-export const INSTALL_INSTRUCTIONS = 'yarn add @web3modal/react @web3modal/ethereum ethers'
+export const INSTALL_INSTRUCTIONS = `yarn add @web3modal/react @web3modal/ethereum ethers`
 
 export const APP_SETUP = `import { Web3Modal } from '@web3modal/react'
 

--- a/src/pages/get-started/index.mdx
+++ b/src/pages/get-started/index.mdx
@@ -33,14 +33,11 @@ import Text from '../../components/Text/Index'
       <Text variant="heading5" color="white" id="app-setup">App Setup</Text>
       <MDXContentBlock>
         In the consuming app:
-        - Import ```Web3ModalProvider``` from ```@web3modal/react```.
-        - Import chains and provider from ```@web3/ethereum```.
-        - Wrap the component with ```Web3ModalProvider```.
+        - Import ```Web3Modal``` from ```@web3modal/react```.
+        - Create a ```config``` object.
         - Set ```projectId``` to ```NEXT_PUBLIC_PROJECT_ID```.
-        - Set chains and providers according to the example code below.
         <CodeSyntax codeString={APP_SETUP} codeType={"app"} />
       </MDXContentBlock>
-
       <Text variant="heading5" color="white" id="get-address">Get Address</Text>
       <MDXContentBlock>
         To get the connected wallet’s address, `import ConnectButton and useAccount from @web3modal/react.`

--- a/src/pages/get-started/index.mdx
+++ b/src/pages/get-started/index.mdx
@@ -41,7 +41,7 @@ import Text from '../../components/Text/Index'
       <Text variant="heading5" color="white" id="get-address">Get Address</Text>
       <MDXContentBlock>
         To get the connected wallet’s address, `import ConnectButton and useAccount from @web3modal/react.`
-        `Connected` is a boolean that will return `true` or `false` if there is a wallet
+        `isConnected` is a boolean that will return `true` or `false` if there is a wallet
         connected. address is the connected wallet’s address.
         <CodeSyntax codeString={GET_CONNECTED_REACT} codeType={"app"} />
       </MDXContentBlock>

--- a/src/pages/get-started/index.mdx
+++ b/src/pages/get-started/index.mdx
@@ -20,7 +20,7 @@ import Text from '../../components/Text/Index'
 
       <Text variant="heading5" color="white" id="wallet-connect-cloud">WalletConnect Cloud</Text>
       <MDXContentBlock>
-        If this is your first time using Web3Modal, you will need to obtain a `projectId`. You can follow [this guide](https://walletconnect.com/) if you need help.
+        If this is your first time using Web3Modal, you will need to obtain a `projectId`. You can follow [this guide](./cloud-explorer/get-project-id) if you need help.
       </MDXContentBlock>
 
       <Text variant="heading5" color="white" id="install">Install</Text>

--- a/src/pages/react/index.mdx
+++ b/src/pages/react/index.mdx
@@ -28,7 +28,7 @@ import { TOC_REACT } from '../../data/TABLE_CONTENTS'
 
       <Text variant="heading4" color="white" id="configure-app">Configure Your App</Text>
       <MDXContentBlock >
-        Add ```import Web3ModalProviderfrom @web3modal/react```. Set projectId to ```YOUR_PROJECT_ID```.
+        Add ```import Web3Modal from @web3modal/react```. Set ```projectId``` to ```YOUR_PROJECT_ID```.
         <CodeSyntax codeString={WEB3_MODAL_REACT} codeType={"app"} />
       </MDXContentBlock>
 


### PR DESCRIPTION
- Remove import for `chains` since it's not actually used in the code example
- Remove wrapping wordage in instructions
- Update 'Web3ModalProvider' to just `Web3Modal`
- Update link from walletconnect.com to the cloud guide
- Update `useConnected` instances to `useAccount`
