### PR TITLE
Docs: update discord link

### DIFF
--- a/src/data/SOCIAL_ICON.tsx
+++ b/src/data/SOCIAL_ICON.tsx
@@ -2,7 +2,7 @@ export const SOCIAL_ICON = [
   {
     title: 'Discord',
     image: '/icons/social/Discord.svg',
-    uri: 'https://discord.com/invite/cB54BwPGru/'
+    uri: 'https://discord.gg/walletconnect'
   },
   {
     title: 'Github',


### PR DESCRIPTION
Curren link to join our Discord is broken:
<img width="883" alt="Screen Shot 2022-11-14 at 11 40 38 AM" src="https://user-images.githubusercontent.com/44731696/201740098-d3fb517f-28a3-49c0-a4ba-467632392da2.png">

Fix: Use permanent link from Discord